### PR TITLE
Refine styling for shift planner interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>シフト作成ツール</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="container">
+        <h1>シフト作成ツール</h1>
+      </div>
+    </header>
+    <main class="page-main" aria-labelledby="main-title">
+      <div class="container">
+        <h2 id="main-title" class="visually-hidden">シフト作成の設定</h2>
+        <section class="panel" aria-labelledby="staff-management-title">
+          <h3 id="staff-management-title">スタッフ管理</h3>
+          <form class="form-inline" id="staff-form">
+            <label for="staff-name">スタッフ名</label>
+            <input
+              type="text"
+              id="staff-name"
+              name="staff-name"
+              autocomplete="name"
+              required
+            />
+            <button type="submit">スタッフを追加</button>
+          </form>
+          <ul id="staff-list" aria-live="polite" aria-label="登録済みスタッフ一覧"></ul>
+        </section>
+
+        <section class="panel" aria-labelledby="target-period-title">
+          <h3 id="target-period-title">対象年月</h3>
+          <form class="form-inline" id="period-form">
+            <label for="target-year">年</label>
+            <select id="target-year" name="target-year"></select>
+            <label for="target-month">月</label>
+            <select id="target-month" name="target-month"></select>
+          </form>
+        </section>
+
+        <section class="panel" aria-labelledby="dayoff-title">
+          <h3 id="dayoff-title">希望休の登録</h3>
+          <form class="form-grid" id="dayoff-form">
+            <div class="form-field">
+              <label for="dayoff-staff">スタッフ名</label>
+              <select id="dayoff-staff" name="dayoff-staff" required>
+                <option value="" disabled selected>スタッフを選択してください</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="dayoff-date">希望休の日付</label>
+              <input type="date" id="dayoff-date" name="dayoff-date" required />
+            </div>
+            <button type="submit" class="primary">希望休を登録</button>
+          </form>
+          <div class="list-wrapper" aria-live="polite">
+            <h4 class="list-title">登録された希望休</h4>
+            <ul id="dayoff-list" aria-label="登録された希望休一覧"></ul>
+          </div>
+        </section>
+
+        <section class="panel" aria-labelledby="action-title">
+          <h3 id="action-title">実行</h3>
+          <button type="button" id="generate-btn" class="primary large">
+            この内容でシフトを作成する
+          </button>
+        </section>
+
+        <section class="panel" aria-labelledby="result-title">
+          <h3 id="result-title">シフト作成結果</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <caption class="visually-hidden">シフト作成結果</caption>
+              <thead>
+                <tr id="result-header-row"></tr>
+              </thead>
+              <tbody id="result-body"></tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+    <footer class="page-footer">
+      <div class="container">
+        <p>© 2024 Shift Planner</p>
+      </div>
+    </footer>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,142 @@
+(function () {
+  const staffForm = document.getElementById('staff-form');
+  const staffNameInput = document.getElementById('staff-name');
+  const staffList = document.getElementById('staff-list');
+  const staffSelect = document.getElementById('dayoff-staff');
+  const yearSelect = document.getElementById('target-year');
+  const monthSelect = document.getElementById('target-month');
+  const dayoffForm = document.getElementById('dayoff-form');
+  const dayoffDateInput = document.getElementById('dayoff-date');
+  const dayoffList = document.getElementById('dayoff-list');
+  const generateBtn = document.getElementById('generate-btn');
+  const resultHeaderRow = document.getElementById('result-header-row');
+
+  const state = {
+    staff: [],
+    dayoffs: [],
+  };
+
+  const init = () => {
+    populateYears();
+    populateMonths();
+    renderHeader();
+  };
+
+  const populateYears = () => {
+    const currentYear = new Date().getFullYear();
+    for (let i = -1; i <= 2; i += 1) {
+      const year = currentYear + i;
+      const option = document.createElement('option');
+      option.value = String(year);
+      option.textContent = `${year}年`;
+      if (i === 0) {
+        option.selected = true;
+      }
+      yearSelect.appendChild(option);
+    }
+  };
+
+  const populateMonths = () => {
+    for (let month = 1; month <= 12; month += 1) {
+      const option = document.createElement('option');
+      option.value = String(month).padStart(2, '0');
+      option.textContent = `${month}月`;
+      if (month === new Date().getMonth() + 1) {
+        option.selected = true;
+      }
+      monthSelect.appendChild(option);
+    }
+  };
+
+  const renderStaffList = () => {
+    staffList.innerHTML = '';
+    staffSelect.innerHTML =
+      '<option value="" disabled selected>スタッフを選択してください</option>';
+
+    state.staff.forEach(name => {
+      const item = document.createElement('li');
+      item.textContent = name;
+      staffList.appendChild(item);
+
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = name;
+      staffSelect.appendChild(option);
+    });
+  };
+
+  const renderDayoffList = () => {
+    dayoffList.innerHTML = '';
+    if (!state.dayoffs.length) {
+      const item = document.createElement('li');
+      item.textContent = '希望休は登録されていません';
+      dayoffList.appendChild(item);
+      return;
+    }
+
+    state.dayoffs.forEach(entry => {
+      const item = document.createElement('li');
+      item.innerHTML = `<strong>${entry.staff}</strong> — ${entry.date}`;
+      dayoffList.appendChild(item);
+    });
+  };
+
+  const renderHeader = () => {
+    resultHeaderRow.innerHTML = '';
+    const selectedYear = Number(yearSelect.value || new Date().getFullYear());
+    const selectedMonth = Number(monthSelect.value || new Date().getMonth() + 1);
+    const daysInMonth = new Date(selectedYear, selectedMonth, 0).getDate();
+
+    const blankTh = document.createElement('th');
+    blankTh.scope = 'col';
+    blankTh.textContent = 'スタッフ名';
+    resultHeaderRow.appendChild(blankTh);
+
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const th = document.createElement('th');
+      th.scope = 'col';
+      th.textContent = `${selectedMonth}/${day}`;
+      resultHeaderRow.appendChild(th);
+    }
+  };
+
+  staffForm.addEventListener('submit', event => {
+    event.preventDefault();
+    const name = staffNameInput.value.trim();
+    if (!name) return;
+    if (state.staff.includes(name)) {
+      alert('このスタッフは既に登録されています。');
+      return;
+    }
+    state.staff.push(name);
+    staffNameInput.value = '';
+    renderStaffList();
+  });
+
+  dayoffForm.addEventListener('submit', event => {
+    event.preventDefault();
+    const staff = staffSelect.value;
+    const date = dayoffDateInput.value;
+    if (!staff || !date) {
+      alert('スタッフと日付を入力してください。');
+      return;
+    }
+    state.dayoffs.push({ staff, date });
+    dayoffDateInput.value = '';
+    renderDayoffList();
+  });
+
+  yearSelect.addEventListener('change', renderHeader);
+  monthSelect.addEventListener('change', renderHeader);
+
+  generateBtn.addEventListener('click', () => {
+    const year = yearSelect.value;
+    const month = monthSelect.value;
+    const message = `シフトを作成します\n対象年月: ${year}年${month}月\nスタッフ数: ${state.staff.length}`;
+    alert(message);
+  });
+
+  init();
+  renderStaffList();
+  renderDayoffList();
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,253 @@
+:root {
+  color-scheme: only light;
+  --max-width: 1000px;
+  --page-background: #f4f4f4;
+  --card-background: #ffffff;
+  --card-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --card-radius: 18px;
+  --border-color: #d8e0ec;
+  --primary-color: #2f80ed;
+  --primary-text: #ffffff;
+  --secondary-button: #e7ecf4;
+  --secondary-button-hover: #d8dfeb;
+  --text-color: #1f2933;
+  --heading-color: #111827;
+  --focus-color: #2563eb;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', 'Hiragino Kaku Gothic ProN', 'Meiryo', sans-serif;
+  background-color: var(--page-background);
+  color: var(--text-color);
+  line-height: 1.6;
+}
+
+.page-header,
+.page-main,
+.page-footer {
+  width: min(var(--max-width), 100%);
+  margin: 0 auto;
+  padding-inline: 1.5rem;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  padding-block: 1.5rem;
+}
+
+.page-header h1,
+.page-footer p {
+  margin: 0;
+  color: var(--heading-color);
+  font-weight: 600;
+}
+
+.page-main {
+  padding-block: 2rem 3rem;
+}
+
+.container {
+  width: 100%;
+  margin: 0 auto;
+}
+
+.panel {
+  background-color: var(--card-background);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  padding: 1.75rem;
+  margin-bottom: 2rem;
+}
+
+.panel:last-of-type {
+  margin-bottom: 0;
+}
+
+.panel h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: var(--heading-color);
+  font-size: 1.35rem;
+}
+
+.panel h4 {
+  margin-top: 0;
+  color: var(--heading-color);
+}
+
+.form-inline,
+.form-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.form-inline {
+  align-items: flex-end;
+}
+
+.form-grid {
+  align-items: flex-end;
+}
+
+.form-field,
+.form-inline label {
+  flex: 1 1 200px;
+  min-width: 200px;
+}
+
+.form-field label,
+.form-inline label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 0.7rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background-color: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+button:focus-visible {
+  outline: none;
+  border-color: var(--focus-color);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.5rem;
+  border: none;
+  border-radius: 999px;
+  background-color: var(--secondary-button);
+  color: var(--heading-color);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+button:hover {
+  background-color: var(--secondary-button-hover);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button.primary {
+  background-color: var(--primary-color);
+  color: var(--primary-text);
+  font-weight: 700;
+}
+
+button.primary:hover {
+  background-color: #1f6bdb;
+}
+
+button.large {
+  width: 100%;
+  padding: 1.1rem;
+  font-size: 1.15rem;
+  border-radius: 16px;
+}
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.list-wrapper {
+  margin-top: 1.25rem;
+  border-top: 1px solid var(--border-color);
+  padding-top: 1rem;
+}
+
+#staff-list li,
+#dayoff-list li {
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.table-wrapper {
+  margin-top: 1.5rem;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+}
+
+thead {
+  background-color: #e1e8f5;
+  color: var(--heading-color);
+}
+
+td,
+th {
+  border: 1px solid var(--border-color);
+  padding: 0.9rem 0.75rem;
+  text-align: center;
+}
+
+tbody td {
+  background-color: #ffffff;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .page-header,
+  .page-main,
+  .page-footer {
+    padding-inline: 1rem;
+  }
+
+  .panel {
+    padding: 1.35rem;
+  }
+
+  .form-inline,
+  .form-grid {
+    flex-direction: column;
+  }
+
+  button.large {
+    font-size: 1.05rem;
+  }
+}


### PR DESCRIPTION
## Summary
- refresh the shift planner stylesheet with centered layout, spacious cards, and soft background
- enhance form controls and buttons for better touch targets, focus states, and hover feedback
- style the results table with full-width layout, contrasting header, and clear borders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb3f6772ac83299455a5d6221f9238